### PR TITLE
Feature/lol/reaper reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Probo Reaper [![Build Status](https://travis-ci.com/ProboCI/probo-reaper.svg?token=pJbXLsRQ8Y3ycLpeAsZF&branch=master)](https://travis-ci.com/ProboCI/probo-reaper)
+
+A tool for removing docker builds when the are no longer needed as
+part of Probo.
+
+The reason for removing a container is emitted as an event and also
+stored. The reasons are stored as non-negative integer codes.
+
+Reaped Reason Codes
+ 0. Unknown.
+ 1. Account over disk limit.
+ 2. Too many builds on the branch.
+ 3. Too many builds on the PR.
+ 4. The PR is closed.

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -10,6 +10,7 @@ var restify = require('restify');
 var through2 = require('through2');
 
 var EventEmitter = events.EventEmitter;
+var reapedReasons = require('./constants');
 
 class Server extends EventEmitter {
 
@@ -214,8 +215,12 @@ class Server extends EventEmitter {
       var pattern = `project_branch_build!!${build.project.id}!!${build.branch.name}!!`;
       var self = this;
       self.getValuesArray(pattern + '!', pattern + '~', function(error, branchBuilds) {
-        var limit = self.getSubscriptionRule(build, 'perBranchBuildLimit');
-        async.map(branchBuilds.slice(0, -1 * limit), self.reap.bind(self), done);
+        let limit = self.getSubscriptionRule(build, 'perBranchBuildLimit');
+        let buildsToReap = branchBuilds.slice(0, -1 * limit);
+        buildsToReap.forEach(function(build) {
+          build.reapedReason = reapedReasons.REAPED_REASON_BRANCH_BUILDS;
+        });
+        async.map(buildsToReap, self.reap.bind(self), done);
       });
     }
     else {
@@ -243,7 +248,7 @@ class Server extends EventEmitter {
     this.log.info(this.getLogContext(build), `Reaping ${build.id} and removing container ${build.container.id}`);
     var self = this;
     var containerId = build.container.id;
-    request.del(`${self.containerManagerUrl}/containers/${containerId}?force=true`, function(error, response, body) {
+    request.del(`${self.containerManagerUrl}/containers/${containerId}?force=true&reason=${build.reapedReason}`, function(error, response, body) {
       if (error) {
         return done(error);
       }
@@ -289,6 +294,7 @@ class Server extends EventEmitter {
       for (let build of organizationBuilds) {
         if (currentUsage > limit) {
           currentUsage -= build.diskSpace.realBytes;
+          build.reapedReason = reapedReasons.REAPED_REASON_DISK_LIMIT;
           buildsToReap.push(build);
         }
       }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ *
+ * Reaped Reason Codes
+ *  0. Unknown
+ *  1. Account over disk limit
+ *  2. Too many builds on the branch
+ *  3. Too many builds on the PR
+ *  4. The PR is closed
+ *
+ */
+
+const REAPED_REASON_UNKNOWN = 0;
+const REAPED_REASON_DISK_LIMIT = 1;
+const REAPED_REASON_BRANCH_BUILDS = 2;
+const REAPED_REASON_PR_BUILDS = 3;
+const REAPED_REASON_PR_CLOSED = 4;
+
+
+module.exports = {
+  REAPED_REASON_UNKNOWN,
+  REAPED_REASON_DISK_LIMIT,
+  REAPED_REASON_BRANCH_BUILDS,
+  REAPED_REASON_PR_BUILDS,
+  REAPED_REASON_PR_CLOSED,
+};

--- a/lib/container_manager.js
+++ b/lib/container_manager.js
@@ -72,10 +72,10 @@ class ContainerManager {
     return containerNames;
   }
 
-  *removeContainer(containerId) {
+  *removeContainer(containerId, reason) {
     var response;
     try {
-      response = yield requestAsync.del(`${this.config.url}/containers/${containerId}`);
+      response = yield requestAsync.del(`${this.config.url}/containers/${containerId}?reason=${reason}`);
     }
     catch (e) {
       response = e.error;

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -3,8 +3,12 @@
 
 var _ = require('lodash');
 
-var PR_STATES = ['open', 'closed'];
-var PR_DEFAULT_STATE = 'open';
+var reapedReasons = require('./constants');
+
+const PR_STATE_OPEN = 'open';
+const PR_STATE_CLOSED = 'closed';
+const PR_STATES = [PR_STATE_OPEN, PR_STATE_CLOSED];
+const PR_DEFAULT_STATE = PR_STATE_OPEN;
 
 
 /**
@@ -37,19 +41,13 @@ function applyCriteria(project, criteria) {
       result = applyBranchCriteria(project, branch, criteria, result);
     });
   }
-  result.remove = result.remove.map(buildToContainerId);
-  result.keep = result.keep.map(buildToContainerId);
 
   // ensure that if something is in 'keep', we remove it from 'remove'
   // because it's possible for a container to be in both.
-  result.remove = _.difference(result.remove, result.keep);
-
+  result.remove = _.differenceBy(result.remove, result.keep, function(obj) {
+    return obj.container.id;
+  });
   return result;
-}
-
-// Map builds to container IDs
-function buildToContainerId(build) {
-  return build.container.id;
 }
 
 function applyBranchCriteria(project, branch, criteria, result) {
@@ -64,7 +62,7 @@ function applyBranchCriteria(project, branch, criteria, result) {
   if (!Number.isNaN(max)) {
     console.log('Applying Branch max:', max);
     console.log('Branch:', branch.branch);
-    result = merge(result, applyMax(branch.builds, max));
+    result = merge(result, applyMax(branch.builds, max, reapedReasons.REAPED_REASON_BRANCH_BUILDS));
   }
   return result;
 }
@@ -79,7 +77,7 @@ function applyPullRequestCriteria(project, state, criteria, result) {
   catch (e) {
     return result;
   }
-  if (stateCriteria && !Number.isNaN(max)) {
+  if (stateCriteria && !isNaN(max)) {
     console.log(`Applying ${state.toUpperCase()} PR max: ${stateCriteria.max}`);
 
     let prsInState = project.pullRequests.filter(function(pr) {
@@ -95,7 +93,11 @@ function applyPullRequestCriteria(project, state, criteria, result) {
 
     prsInState.forEach(function(pr) {
       console.log('PR:', pr.pr, pr.state);
-      result = merge(result, applyMax(pr.builds, stateCriteria.max));
+      let reason = reapedReasons.REAPED_REASON_PR_BUILDS;
+      if (pr.state === PR_STATE_CLOSED) {
+        reason = reapedReasons.REAPED_REASON_PR_CLOSED;
+      }
+      result = merge(result, applyMax(pr.builds, stateCriteria.max, reason));
     });
   }
   return result;
@@ -115,12 +117,12 @@ function applyPullRequestCriteria(project, state, criteria, result) {
  */
 function merge(existing, current) {
   for (let key in current) {
-    existing[key] = _.uniq(_.union(existing[key], current[key]), 'id');
+    existing[key] = _.uniqBy(_.union(existing[key], current[key]), 'id');
   }
   return existing;
 }
 
-function applyMax(array, max) {
+function applyMax(array, max, reason) {
   if (!array) {
     throw new Error('Array argument required');
   }
@@ -128,10 +130,14 @@ function applyMax(array, max) {
     throw new Error('Invalid max pull requests criteria value: ' + max);
   }
 
-  return {
+  let applied = {
     remove: array.slice(max),
     keep: array.slice(0, max),
   };
+  applied.remove.forEach(function(obj) {
+    obj.reason = reason;
+  });
+  return applied;
 }
 
 

--- a/lib/reaper.js
+++ b/lib/reaper.js
@@ -188,17 +188,18 @@ function* start() {
       // returns {remove, keep} arrays of container IDs to remove and keep, respectively
       let containerActions = criteria.apply(project, project.reaperCriteria);
       console.log('container actions:', containerActions);
-      for (let containerId of containerActions.remove) {
-        console.log('removing container', containerId);
+      for (let buildData of containerActions.remove) {
+        console.log('removing container', buildData.id);
+        console.log('reason for reap: ', buildData.reason);
 
         if (proboConfig['dry-run']) {
-          console.log(`DRY RUN: container ${containerId} NOT being removed`);
+          console.log(`DRY RUN: container ${buildData.id} NOT being removed`);
         }
         else {
-          let resp = yield* cm.removeContainer(containerId);
+          let resp = yield* cm.removeContainer(buildData.container.id, buildData.reason);
           console.log(resp);
         }
-        console.log(`removed container  ${containerId}`);
+        console.log(`removed container: ${buildData.container.id}, because: ${buildData.reason}`);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Cleans up old Probo containers and ensures that only the allocated number of containers exist.",
   "main": "index.js",
   "bin": {
-    "probo-reaper": "./bin/reaper"
+    "probo-reaper": "./bin/probo-reaper"
   },
   "scripts": {
     "test": "mocha --recursive --require should",
@@ -37,7 +37,7 @@
     "github": "^0.2.4",
     "leveldown": "^1.4.4",
     "levelup": "^1.3.1",
-    "lodash": "^3.10.1",
+    "lodash": "^4.15.0",
     "probo-eventbus": "^0.2.0",
     "querystring": "^0.2.0",
     "request": "^2.72.0",

--- a/test/criteria.js
+++ b/test/criteria.js
@@ -1,5 +1,6 @@
 /* eslint no-multi-spaces: 0, key-spacing: 0 */
 'use strict';
+var _ = require('lodash');
 
 // To test:
 // 1 - max per branch
@@ -42,18 +43,49 @@ describe('criteria', function(done) {
     applyMax.bind(null, [], 0).should.not.throw();
     applyMax.bind(null, [], 3).should.not.throw();
 
-    let array = [1, 2, 3, 4, 5];
-    applyMax(array,  0).should.eql({keep: [],              remove: [1, 2, 3, 4, 5]});
-    applyMax(array,  1).should.eql({keep: [1],             remove: [2, 3, 4, 5]});
-    applyMax(array,  2).should.eql({keep: [1, 2],          remove: [3, 4, 5]});
-    applyMax(array,  5).should.eql({keep: [1, 2, 3, 4, 5], remove: []});
-    applyMax(array, 10).should.eql({keep: [1, 2, 3, 4, 5], remove: []});
+    let array = _.map([1, 2, 3, 4, 5], function(num) {
+      return {id: num};
+    });
+
+    let getObjId = function(obj) {
+      return obj.id;
+    };
+
+    _.map(applyMax(array, 0).keep, getObjId)
+      .should.eql([]);
+
+    _.map(applyMax(array, 0).remove, getObjId)
+      .should.eql([1, 2, 3, 4, 5]);
+
+    _.map(applyMax(array, 1).keep, getObjId)
+      .should.eql([1]);
+
+    _.map(applyMax(array, 1).remove, getObjId)
+      .should.eql([2, 3, 4, 5]);
+
+    _.map(applyMax(array, 2).keep, getObjId)
+      .should.eql([1, 2]);
+
+    _.map(applyMax(array, 2).remove, getObjId)
+      .should.eql([3, 4, 5]);
+
+    _.map(applyMax(array, 5).keep, getObjId)
+      .should.eql([1, 2, 3, 4, 5]);
+
+    _.map(applyMax(array, 5).remove, getObjId)
+      .should.eql([]);
+
+    _.map(applyMax(array, 10).keep, getObjId)
+      .should.eql([1, 2, 3, 4, 5]);
+
+    _.map(applyMax(array, 10).remove, getObjId)
+      .should.eql([]);
   });
 
   it('criteria gets applied correctly', function() {
-    var project = projects[0];
+    let project = projects[0];
 
-    var criteria = {
+    let criteria = {
       pullRequest: {
         open: {
           max: 2,
@@ -67,24 +99,30 @@ describe('criteria', function(done) {
       },
     };
 
-    var applyCriteria = lib.apply;
+    let applyCriteria = lib.apply;
 
-    // missing criteria
+    // Missing criteria
     applyCriteria.bind(null, {}).should.throw('project and criteria are required.');
 
-    applyCriteria(project, criteria).should.eql({
-      remove: [
-        'container 0',
-        'container 6',
-        'container 5',
-        'container pre-3',
-      ],
-      keep: [
-        'container 2',
-        'container 1',
-        'container 4',
-        'container 3',
-      ],
-    });
+    let actions = applyCriteria(project, criteria);
+    actions.remove.map(function(obj) {
+      return obj.container.id;
+    })
+    .should.eql([
+      'container 0',
+      'container 6',
+      'container 5',
+      'container pre-3',
+    ]);
+
+    actions.keep.map(function(obj) {
+      return obj.container.id;
+    })
+    .should.eql([
+      'container 2',
+      'container 1',
+      'container 4',
+      'container 3',
+    ]);
   });
 });

--- a/test/server.js
+++ b/test/server.js
@@ -16,7 +16,7 @@ var Server = lib.Server;
 
 nock('http://localhost:9631')
   .persist()
-  .delete('/containers/some%20container?force=true')
+  .delete(/\/containers\/some\%20container\?force\=true\&reason\=.*/)
   .reply(200);
 
 // We use a simple method to reset the world between tests by


### PR DESCRIPTION
See also
https://github.com/ProboCI/probo/pull/80
and
https://github.com/ProboCI/probo-coordinator/pull/87

This adds numeric reason codes to the data the reaper uses to request the deletion of containers.
### To test
- Run the reaper via the command line. If there are things to reap, you should see console output that reveals what will be kept and what will be removed. In this data you should see a `reapedReason` code.
