### PR TITLE
Fix reaper prioritization.

### DIFF
--- a/bin/probo-reaper
+++ b/bin/probo-reaper
@@ -72,6 +72,7 @@ function reap() {
       console.error(error);
       throw error;
     }
+
     reaper.run(config);
   });
 }

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -32,3 +32,11 @@ codeHostingHandlers:
   bitbucket: 'http://localhost:3012'
 
 perBranchBuildLimit: 1
+
+reaperCriteria:
+  pullRequest:
+    open:
+      max: 1,
+      maxAge: ''
+    closed:
+      max: 0

--- a/lib/criteria.js
+++ b/lib/criteria.js
@@ -137,13 +137,21 @@ function applyMax(array, max, reason) {
     throw new Error('Invalid max pull requests criteria value: ' + max);
   }
 
+  let pinned = array.filter(function(item) {
+    return item.pinned;
+  });
+  let unpinned = array.filter(function(item) {
+    return !item.pinned;
+  });
   let applied = {
-    remove: array.slice(max),
-    keep: array.slice(0, max),
+    remove: unpinned.slice(max),
+    keep: pinned.concat(unpinned.slice(0, max)),
   };
+
   applied.remove.forEach(function(obj) {
     obj.reason = reason;
   });
+
   return applied;
 }
 

--- a/lib/reaper.js
+++ b/lib/reaper.js
@@ -56,8 +56,9 @@ function* buildsToProjects(builds) {
       project.pullRequests = [];
       project.branches = [];
 
-      // ensure there's a reaperCriteria set on the project, defaut if necessary
-      project.reaperCriteria = project.reaperCriteria || DEFAULT_CRITERIA;
+      // ensure there's a reaperCriteria set on the project, default if necessary
+      let defaultReaperCriteria = proboConfig.reaperCriteria || DEFAULT_CRITERIA;
+      project.reaperCriteria = project.reaperCriteria || defaultReaperCriteria;
     }
     project.builds.push(build);
 

--- a/test/fixtures/builds.json
+++ b/test/fixtures/builds.json
@@ -123,7 +123,7 @@
     },
     "createdAt": "2016 -0 9 -0 1T19: 36: 35.526Z"
   },
-    {
+  {
     "id": "70ad26f9-98f1-4a49-9812-876addaf380d",
     "branch": {
       "htmlUrl": "https://example.com/test/test",

--- a/test/reaper.js
+++ b/test/reaper.js
@@ -38,7 +38,7 @@ describe('Reaper', function() {
       done();
     });
 
-    it('should prioritize pinned builds', function(done) {
+    it('should not remove pinned builds', function(done) {
       var error = null;
       should.not.exist(error);
       var cm = new ContainerManager({url: `http://${config.cmHostname}:${config.cmPort}`});
@@ -56,10 +56,15 @@ describe('Reaper', function() {
           });
           reapActions.should.be.instanceof(Array).and.have.lengthOf(1);
           let actions = reapActions[0];
+
+          // There are 4 builds in the test data. One is pinned. Therefore there
+          // should be 2 marked for removal and 2 marked to keep.
+          // Pinned builds should not be counted towards the limit. The default
+          // limit is one per PR.
           actions.should.be.instanceof(Object);
           actions.should.have.property('keep');
           actions.should.have.property('remove');
-          actions.keep.should.be.instanceof(Array).and.have.lengthOf(1);
+          actions.keep.should.be.instanceof(Array).and.have.lengthOf(2);
           let build = actions.keep[0];
           build.container.id.should.equal('cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc');
           done();


### PR DESCRIPTION
The reaper's standalone mode had been improperly marking some
builds for deletion. This was a result of calculating the number
of builds on a PR before removing the pinned builds from the
list. The result is that pinned builds would never be removed but
unpinned builds that shouldn't be were being reaped. This change
removes the pinned builds from the lists before it calculates the
number of builds on the branch. Then the pinned builds are added
back to the array of items to keep.
- Fix reap criteria logic
- Adjust tests
- Ensure we can set reaper criteria settings from config files
### To Test
- Add the follow yaml to the reaper config on your test server.

``` yaml
reaperCriteria:
  pullRequest:
    open:
      max: 5
      maxAge: ''
    closed:
      max: 0
```
- Ensure reaper server is off
- Create a PR and make 8 builds by clicking the rebuild button
- Pin three builds at random
- Run the reaper in standalone mode
- Ensure nothing is removed.
- Build 2 more build and do not pin them
- Run the reaper again in standalone mode and ensure the two oldest unpinned builds are removed.
