### PR TITLE
Support reap events

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -163,7 +163,7 @@ class Server extends EventEmitter {
         return self.log.error(error);
       }
       self.enforceLimits(build, done);
-      self.emit('buildReceived');
+      self.emit('buildReceived', build);
     });
   }
 
@@ -173,7 +173,7 @@ class Server extends EventEmitter {
       if (error) {
         return self.log.error(error);
       }
-      self.emit('updateReceived');
+      self.emit('updateReceived', build);
       done();
     });
   }
@@ -184,7 +184,8 @@ class Server extends EventEmitter {
       if (error) {
         return self.log.error(error);
       }
-      self.emit('updateReceived');
+      self.log.info(self.getLogContext(build), `Reap event received, removed build ${build.id} from the database due.`);
+      self.emit('reapReceived', build);
       done();
     });
   }
@@ -443,11 +444,9 @@ class Server extends EventEmitter {
   start(done) {
     var self = this;
     this.consumer.stream.pipe(through2.obj(function(data, enc, cb) {
-      self.messageProcessor(data, function() {
-        cb();
-      });
+      self.messageProcessor(data, cb);
     }));
-    this.log.info(`Now subscribed to events on ${this.consumer.topic}`);
+    this.log.info(`Now subscribed to events on eventbus topic ${this.consumer.topic}`);
     if (done) done();
   }
 

--- a/test/server.js
+++ b/test/server.js
@@ -136,6 +136,8 @@ describe('Server', function() {
       stream.write(getTestBuildEvent({id: 'build 2', project: {id: 'project 2'}}));
       server.on('buildReceived', getEventCounter(2, function() {
         server.getKeyAndValueArray('!', '~', function(error, records) {
+          let reapReceived = false;
+          server.on('reapReceived', () => { reapReceived = true;});
           should.exist(server);
           records.length.should.equal(8);
           records[0].key.should.equal('build!!build 1');
@@ -143,6 +145,7 @@ describe('Server', function() {
           stream.write(getTestBuildEvent(false, {event: 'reaped'}));
           server.getKeyAndValueArray('!', '~', function(error, records) {
             should.exist(server);
+            reapReceived.should.equal(true);
             records.length.should.equal(4);
             records[0].key.should.equal('build!!build 2');
             done();


### PR DESCRIPTION
Currently, we have no support for reap events in the reaper server so if a build is deleted out of band the reaper will not be aware of it.

To test you could run a build, manually delete it, then dump the data using the backup endpoint:

1. Run a build
2. Check that that build is in the reaper database (now you see it: `curl localhost:3038/api/export-data | jq .key | grep 'build!![build id]'` )
3. Manually delete it in the UI
4. Check that the build is not in the reaper database (now you don't: `curl localhost:3038/api/export-data | jq .key | grep 'build!![build id]'`)