### PR TITLE
Add support for the eventbus 1.0.0 commit streams

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,3 @@ script:
   - npm run coverage
 after_script:
   - ./node_modules/.bin/coveralls < ./coverage/lcov.info
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-env:
-  - CXX=g++-4.8

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -459,9 +459,9 @@ class Server extends EventEmitter {
       autoCommitIntervalMs: 1000,
       autoCommitMsgCount: 1000,
     };
-    this.consumer.rawStream
+    self.consumer.rawStream
       .pipe(through2.obj(function(data, enc, cb) {
-        self.log.info('Eventbus event received', data);
+        self.log.trace('Eventbus event received', data);
         if (!data || !data.data || !data.data.build) {
           self.log.error('Invalid build message received', data);
           return cb(null, data);
@@ -470,13 +470,16 @@ class Server extends EventEmitter {
           cb(null, data);
         });
       }))
-      .pipe(this.consumer.createCommitStream(commitStreamOptions));
-    this.log.info(`Now subscribed to events on eventbus topic ${this.consumer.topic}`);
-    this.server.listen(this.apiServerPort, this.apiServerHost, function() {
+      .pipe(self.consumer.createCommitStream(commitStreamOptions));
+    self.server.listen(self.apiServerPort, self.apiServerHost, function() {
       let address = self.server.address();
       self.log.info(`REST API listening at ${address.address}:${address.port}`);
       if (done) done();
     });
+    self.consumer.rawStream.on('error', function(error) {
+      self.log.error(error);
+    });
+    self.log.info(`Now subscribed to events on ${self.consumer.topic}`);
   }
 
   stop(done) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "leveldown": "^1.4.4",
     "levelup": "^1.3.1",
     "lodash": "^4.17.4",
-    "probo-eventbus": "^1.0.2",
+    "probo-eventbus": "^1.0.3",
     "querystring": "^0.2.0",
     "request": "^2.72.0",
     "request-promise": "^1.0.2",
@@ -51,7 +51,7 @@
     "eslint": "^1.10.1",
     "eslint-config-probo": "^1.0.2",
     "istanbul": "^0.4.2",
-    "memdown": "^1.2.0",
+    "memdown": "^1.2.4",
     "mocha": "^2.3.4",
     "nock": "^8.0.0",
     "should": "^7.1.1"


### PR DESCRIPTION
This will allow us to consume builds from the beginning of time and commit only messages we have successfully processed making restarts safe.