### PR TITLE
Remove non-numeric characters from disk usage in case there are quotes

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -494,8 +494,7 @@ class Server extends EventEmitter {
         return done(error);
       }
       self.log.info(body);
-      body.replace(/[^0-9]/g, '');
-      done(null, body);
+      done(null, body.replace(/\D/g, ''));
     });
   }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -494,6 +494,7 @@ class Server extends EventEmitter {
         return done(error);
       }
       self.log.info(body);
+      body.replace(/[^0-9]/g, '');
       done(null, body);
     });
   }

--- a/test/server.js
+++ b/test/server.js
@@ -70,7 +70,7 @@ function setUpDbApiResponses(responses, organization) {
   responses.forEach(response => {
     nock('http://localhost:9876')
       .get(`/organization/${organization}/disk-usage`)
-      .reply(200, response + '');
+      .reply(200, '"' + response + '"');
   });
 }
 


### PR DESCRIPTION
The reaper gets disk usage information from the probo-db but that number can have quotes around it.  This causes issues in the reaper because it's not read as a real number.

This change clears up any non-numeric characters when reading the disk total so that it won't report  that the disk usage is NaN.